### PR TITLE
Send output to stdout with optional --output parameter for saving to file

### DIFF
--- a/test_tokenparsing.py
+++ b/test_tokenparsing.py
@@ -99,10 +99,10 @@ def test_validate_token_fails_for_invalid_token():
 
 
 def test_main_fails_if_validate_token_fails():
-    with patch('main.get_token_from_file', return_value='test-token'):
+    with patch('utils.get_token_from_file', return_value='test-token'):
         with patch('main.validate_token', return_value=False):
             with pytest.raises(Exception) as pytest_wrapped_exception:
-                main.main(['--orgId', 'abc123', '--projectIds', '1232'])
+                main.main(['--orgId', 'abc123', '--projectIds', '123'])
             assert pytest_wrapped_exception.type == main.SnykTokenInvalidError
 
 

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import requests
 import json
 import os
+from sys import stderr
 
 
 def get_default_token_path():
@@ -19,12 +20,12 @@ def get_token_from_file(token_file_path):
             token = json_obj["api"]
             return token
     except FileNotFoundError as fnfe:
-        print("Snyk auth token not found at %s" % path)
-        print("Run `snyk auth` (see https://github.com/snyk/snyk#installation) or manually create this file with your token.")
+        print("Snyk auth token not found at %s" % path, file=stderr)
+        print("Run `snyk auth` (see https://github.com/snyk/snyk#installation) or manually create this file with your token.", file=stderr)
         raise fnfe
     except KeyError as ke:
-        print("Snyk auth token file is not properly formed: %s" % path)
-        print("Run `snyk auth` (see https://github.com/snyk/snyk#installation) or manually create this file with your token.")
+        print("Snyk auth token file is not properly formed: %s" % path, file=stderr)
+        print("Run `snyk auth` (see https://github.com/snyk/snyk#installation) or manually create this file with your token.", file=stderr)
         raise ke
 
 


### PR DESCRIPTION
feat: send main output (threadfix data) to stdout and log/error messages to stderr. Add optional --output parameter to save output to given filename. Add optional --debug parameter to get additional logging (to stderr).
