### PR TITLE
Link referenceLink to vuln instance in Snyk

### DIFF
--- a/snyk_threadfix/main.py
+++ b/snyk_threadfix/main.py
@@ -182,7 +182,7 @@ def create_threadfix_findings_data(org_id, project_id):
                 'library': i.package,
                 'description': 'You can find the description here: %s' % i.url,
                 'reference': i.id,
-                'referenceLink': i.url,
+                'referenceLink': "%s#issue-%s" % (p.browseUrl, i.id),
                 'filePath': target_file,
                 'version': i.version,
                 'issueType': 'VULNERABILITY',


### PR DESCRIPTION
Update how `referenceLink` is set. Make it a link to the project + instance of the vuln in Snyk.
