### PR TITLE
No stdout if --output option used

### DIFF
--- a/snyk_threadfix/main.py
+++ b/snyk_threadfix/main.py
@@ -256,9 +256,11 @@ def main(args):
         all_threadfix_findings.extend(threadfix_findings)
 
     threadfix_json_obj['findings'] = all_threadfix_findings
-    write_output_to_stdout(threadfix_json_obj)
+
     if args.output:
         write_to_threadfix_file(args.output, threadfix_json_obj)
+    else:
+        write_output_to_stdout(threadfix_json_obj)
 
 
 def run():


### PR DESCRIPTION
Do not dump the output json/ThreadFix data to stdout if the user uses the `--output=<filepath>` option.