### PR TITLE
Remove filePathList

### DIFF
--- a/snyk_threadfix/main.py
+++ b/snyk_threadfix/main.py
@@ -162,12 +162,6 @@ git_repo_project_origins = [
 
 def create_finding_data(org_id, snyk_project, snyk_project_metadata, snyk_vulnerability):
     native_id = generate_native_id(org_id, snyk_project.id, snyk_vulnerability.id, snyk_vulnerability.fromPackages)
-    target_file = snyk_project_metadata.get('targetFile')
-
-    file_path = target_file if target_file \
-        else '>'.join(snyk_vulnerability.fromPackages)
-
-    file_path_list = [file_path]
 
     finding = {
         'nativeId': native_id,
@@ -183,7 +177,6 @@ def create_finding_data(org_id, snyk_project, snyk_project_metadata, snyk_vulner
             'description': 'You can find the description here: %s' % snyk_vulnerability.url,
             'reference': snyk_vulnerability.id,
             'referenceLink': "%s#issue-%s" % (snyk_project.browseUrl, snyk_vulnerability.id),
-            'filePathList': file_path_list,
             'version': snyk_vulnerability.version,
             'issueType': 'VULNERABILITY',
         },

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -429,10 +429,6 @@ def test_create_finding_data_regular_project_from_git_repo():
     assert tf_finding['dependencyDetails']['reference'] == snyk_vulnerability['id']
     assert tf_finding['dependencyDetails']['referenceLink'] == "%s#issue-%s" % (snyk_project['browseUrl'], snyk_vulnerability['id'])
 
-    assert 'filePath' not in tf_finding['dependencyDetails']
-    assert len(tf_finding['dependencyDetails']['filePathList']) == 1
-    assert tf_finding['dependencyDetails']['filePathList'][0] == 'package.json'
-
     assert tf_finding['dependencyDetails']['version'] == snyk_vulnerability['version']
     assert tf_finding['dependencyDetails']['issueType'] == 'VULNERABILITY'
 
@@ -552,10 +548,6 @@ def test_create_finding_data_regular_project_from_cli_project_with_custom_name()
     assert tf_finding['dependencyDetails']['description'] == 'You can find the description here: %s' % snyk_vulnerability['url']
     assert tf_finding['dependencyDetails']['reference'] == snyk_vulnerability['id']
     assert tf_finding['dependencyDetails']['referenceLink'] == "%s#issue-%s" % (snyk_project['browseUrl'], snyk_vulnerability['id'])
-
-    assert 'filePath' not in tf_finding['dependencyDetails']
-    assert len(tf_finding['dependencyDetails']['filePathList']) == 1
-    assert tf_finding['dependencyDetails']['filePathList'][0] == 'org.openapitools:openapi-generator@3.2.3>org.slf4j:slf4j-ext@1.7.12'
 
     assert tf_finding['dependencyDetails']['version'] == snyk_vulnerability['version']
     assert tf_finding['dependencyDetails']['issueType'] == 'VULNERABILITY'


### PR DESCRIPTION
Remove `filePathList` because we don't typically have a physical file path so it doesn't really make sense