### PR TITLE
fix: Release on develop instead of master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,4 +138,4 @@ workflows:
             - test_deps
           filters:
             branches:
-              only: master
+              only: develop

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # snyk-threadfix
 
-|           | master | develop |
-|:----------|:-------|:--------|
-| CI Status |[![CircleCI](https://circleci.com/gh/snyk-labs/snyk-threadfix/tree/master.svg?style=svg)](https://circleci.com/gh/snyk-labs/snyk-threadfix/tree/master)|[![CircleCI](https://circleci.com/gh/snyk-labs/snyk-threadfix/tree/develop.svg?style=svg)](https://circleci.com/gh/snyk-labs/snyk-threadfix/tree/develop)|
+|           | develop |
+|:----------|:--------|
+| CI Status |[![CircleCI](https://circleci.com/gh/snyk-labs/snyk-threadfix/tree/develop.svg?style=svg)](https://circleci.com/gh/snyk-labs/snyk-threadfix/tree/develop)|
 
 
 The ThreadFix / Snyk integration allows you to view open source vulnerabilities identified by Snyk on the ThreadFix platform and direct you to comprehensive information and remediation guidance.


### PR DESCRIPTION
We do not use the master branch anymore so get rid of the references to
it.